### PR TITLE
validate version provided by user

### DIFF
--- a/.github/workflows/approve-or-deny-request.yml
+++ b/.github/workflows/approve-or-deny-request.yml
@@ -23,6 +23,25 @@ jobs:
     needs: parse-issue
     if: needs.parse-issue.outputs.payload != 'NOT_FOUND'
     steps:
+    - name: Lookup the latest release of ${{ fromJson(needs.parse-issue.outputs.payload).owner }}/${{ fromJson(needs.parse-issue.outputs.payload).repo }}
+      id: get_version
+      env:
+        OWNER: ${{ fromJson(needs.parse-issue.outputs.payload).owner }}
+        REPO: ${{ fromJson(needs.parse-issue.outputs.payload).repo }}
+        REQUEST_VERSION: ${{ fromJson(needs.parse-issue.outputs.payload).version }}
+      run: |
+        if [ $REQUEST_VERSION == 'latest' ]; then
+          export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
+        else
+          if curl -f https://api.github.com/repos/$OWNER/$REPO/releases/tags/$REQUEST_VERSION; then
+            export VERSION=$REQUEST_VERSION
+          else
+            echo "VERSION: $REQUEST_VERSION does not exists"
+            exit 1
+          fi
+        fi
+        echo "VERSION: $VERSION"
+        echo "::set-output name=version::$VERSION"
     - name: Check out scripts
       uses: actions/checkout@v2
     - name: Setup Node
@@ -34,20 +53,6 @@ jobs:
       run: |
         cd .github/scripts
         npm install
-    - name: Lookup the latest release of ${{ fromJson(needs.parse-issue.outputs.payload).owner }}/${{ fromJson(needs.parse-issue.outputs.payload).repo }}
-      id: get_version
-      env:
-        OWNER: ${{ fromJson(needs.parse-issue.outputs.payload).owner }}
-        REPO: ${{ fromJson(needs.parse-issue.outputs.payload).repo }}
-        REQUEST_VERSION: ${{ fromJson(needs.parse-issue.outputs.payload).version }}
-      run: |
-        if [ $REQUEST_VERSION == 'latest' ]; then
-          export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
-        else
-          export VERSION=$REQUEST_VERSION
-        fi
-        echo "VERSION: $VERSION"
-        echo "::set-output name=version::$VERSION"
     - name: Approve or deny request
       uses: actions/github-script@main
       with:

--- a/.github/workflows/initialize-request.yml
+++ b/.github/workflows/initialize-request.yml
@@ -23,6 +23,25 @@ jobs:
     needs: parse-issue
     if: needs.parse-issue.outputs.payload != 'NOT_FOUND'
     steps:
+    - name: Lookup the latest release of ${{ fromJson(needs.parse-issue.outputs.payload).owner }}/${{ fromJson(needs.parse-issue.outputs.payload).repo }}
+      id: get_version
+      env:
+        OWNER: ${{ fromJson(needs.parse-issue.outputs.payload).owner }}
+        REPO: ${{ fromJson(needs.parse-issue.outputs.payload).repo }}
+        REQUEST_VERSION: ${{ fromJson(needs.parse-issue.outputs.payload).version }}
+      run: |
+        if [ $REQUEST_VERSION == 'latest' ]; then
+          export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
+        else
+          if curl -f https://api.github.com/repos/$OWNER/$REPO/releases/tags/$REQUEST_VERSION; then
+            export VERSION=$REQUEST_VERSION
+          else
+            echo "VERSION: $REQUEST_VERSION does not exists"
+            exit 1
+          fi
+        fi
+        echo "VERSION: $VERSION"
+        echo "::set-output name=version::$VERSION"
     - name: Check out scripts
       uses: actions/checkout@v2
     - name: Setup Node
@@ -34,20 +53,6 @@ jobs:
       run: |
         cd .github/scripts
         npm install
-    - name: Lookup the latest release of ${{ fromJson(needs.parse-issue.outputs.payload).owner }}/${{ fromJson(needs.parse-issue.outputs.payload).repo }}
-      id: get_version
-      env:
-        OWNER: ${{ fromJson(needs.parse-issue.outputs.payload).owner }}
-        REPO: ${{ fromJson(needs.parse-issue.outputs.payload).repo }}
-        REQUEST_VERSION: ${{ fromJson(needs.parse-issue.outputs.payload).version }}
-      run: |
-        if [ $REQUEST_VERSION == 'latest' ]; then
-          export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
-        else
-          export VERSION=$REQUEST_VERSION
-        fi
-        echo "VERSION: $VERSION"
-        echo "::set-output name=version::$VERSION"
     - name: Create the repo ${{ fromJson(needs.parse-issue.outputs.payload).repo }}_${{ steps.get_version.outputs.version }} on GitHub Enterprise Server
       uses: actions/github-script@main
       with:


### PR DESCRIPTION
This change validates the version provided by the user. When the version is not found in the requested action repo, the workflow fails.
<img width="685" alt="Screen Shot 2022-09-16 at 10 45 58 AM" src="https://user-images.githubusercontent.com/95243761/190701037-86875150-b7ec-47de-946b-28a244d4d9d0.png">
