### PR TITLE
Update set-output to use the new syntax

### DIFF
--- a/.github/workflows/approve-or-deny-request.yml
+++ b/.github/workflows/approve-or-deny-request.yml
@@ -43,7 +43,7 @@ jobs:
           fi
         fi
         echo "VERSION: $VERSION"
-        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Check out scripts
       uses: actions/checkout@v3
     - name: Setup Node

--- a/.github/workflows/initialize-request.yml
+++ b/.github/workflows/initialize-request.yml
@@ -43,7 +43,7 @@ jobs:
           fi
         fi
         echo "VERSION: $VERSION"
-        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Check out scripts
       uses: actions/checkout@v3
     - name: Setup Node


### PR DESCRIPTION
Update set-output to use the new syntax.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/