### PR TITLE
Allow for the case where the release name and tag differ

### DIFF
--- a/.github/workflows/approve-or-deny-request.yml
+++ b/.github/workflows/approve-or-deny-request.yml
@@ -34,13 +34,7 @@ jobs:
           echo "Finding latest release of $OWNER/$REPO..."
           export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
         else
-          echo "Validating the requested version $REQUEST_VERSION exists..."
-          if curl -f https://api.github.com/repos/$OWNER/$REPO/releases/tags/$REQUEST_VERSION; then
-            export VERSION=$REQUEST_VERSION
-          else
-            echo "VERSION: $REQUEST_VERSION does not exists"
-            exit 1
-          fi
+          export VERSION=$REQUEST_VERSION
         fi
         echo "VERSION: $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/initialize-request.yml
+++ b/.github/workflows/initialize-request.yml
@@ -34,13 +34,7 @@ jobs:
           echo "Finding latest release of $OWNER/$REPO..."
           export VERSION=`curl https://api.github.com/repos/$OWNER/$REPO/releases/latest | jq -r .name`
         else
-          echo "Validating the requested version $REQUEST_VERSION exists..."
-          if curl -f https://api.github.com/repos/$OWNER/$REPO/releases/tags/$REQUEST_VERSION; then
-            export VERSION=$REQUEST_VERSION
-          else
-            echo "VERSION: $REQUEST_VERSION does not exists"
-            exit 1
-          fi
+          export VERSION=$REQUEST_VERSION
         fi
         echo "VERSION: $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ You may already have requests for marketplace actions occuring in another repo, 
 1. Make sure the [prerequisutes](#prerequisites) above are met.
 1. Follow the [setup](#setup) instructions above on the repo you intent to use.
 1. Move the contents of the this repos .github directory into the .github directory of the repo you intent to use. Be careful not to clobber any existing files in the .github repo!
+
+## Troubleshooting
+When specifying the details of the actions repo you are requesting, if the release name and the tag name of the release in that repo do not match, you will need to use the tag name for the version. When specifying the version as `latest` the assumption is that the release name and the tag name of the release match. If this is not the case, you will need to speficy the tag name as the vesion rather than using `latest`.


### PR DESCRIPTION
Allow for the case where the release name and tag names are different. To do so, do not validate the release name as the version requested. This should always match the tag name.