### PR TITLE
Update ownership.yaml

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -6,7 +6,7 @@ ownership:
   maintainer: robandpdx
   team: github/ps-amer
   team_slack: services-delivery
-  exec_sponsor: naval-gupta
+  exec_sponsor: scotcar
   repo: https://github.com/github/request-marketplace-action
   sev1:
     issue: https://github.com/github/request-marketplace-action/issues 


### PR DESCRIPTION
This pull request updates the `ownership.yaml` file to reflect a change in the executive sponsor for the project.

* [`ownership.yaml`](diffhunk://#diff-292969d018102fc5ba9276babb6cac1a6aa0f98b3b861f5f1f26b0ce8f1df3e1L9-R9): Updated the `exec_sponsor` field from `naval-gupta` to `scotcar`.